### PR TITLE
[codex] Prepare 0.3.4 release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Docs
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  readthedocs:
+    name: Read the Docs build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install documentation dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
+        python -m pip install .
+
+    - name: Build docs (strict)
+      run: sphinx-build -W -b html docs/source docs/build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,5 @@ sphinx:
 python:
   install:
    - requirements: docs/requirements.txt
+   - method: pip
+     path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.3.4
+
+- Replaced deprecated `pkg_resources` usage in session information reporting.
+- Updated supporting documentation and dependency metadata for the current release.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 docs:
-	. .venv/bin/activate; cd docs; sphinx-build source build; deactivate
+	. .venv/bin/activate; pip install -q -r docs/requirements.txt -e .; cd docs; sphinx-build -W -b html source build; deactivate
 
 # Reminder: To run tests locally against several OS/Python combos, run `act`
 test:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-m2r2
+myst-parser
 nbconvert==7.17.1
 numpy==1.22.0
 lxml_html_clean

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ author = u'Christopher Baker'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'0.3.3'
+release = u'0.3.4'
 
 # -- General configuration ---------------------------------------------------
 
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    'm2r2'
+    'myst_parser',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -49,7 +49,10 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # source_parsers = {
 #    '.md': 'recommonmark.parser.CommonMarkParser',
@@ -69,6 +72,8 @@ master_doc = 'index'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = []
+
+suppress_warnings = ['myst.header']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -1,3 +1,5 @@
+:orphan:
+
 ## FAQs
 
 **1. How do I suppress the output the intermediate matplotlib functions in my reprex?**

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,17 @@
 reprexpy
 ====================================
 
-.. mdinclude:: ../../README.md
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
    :start-line: 2
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-.. mdinclude:: faqs.md
+   modules
+.. include:: faqs.md
+   :parser: myst_parser.sphinx_
 
 Reference
 ------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 
 setup(
     name='reprexpy',
-    version='0.3.3',
+    version='0.3.4',
     description='Render reproducible examples of Python code (port of R '
                 'package `reprex`)',
     long_description=long_description,


### PR DESCRIPTION
## Summary

Prepares the 0.3.4 release and fixes the broken Read the Docs build on `master`.

Changes:
- Bump the package version from 0.3.3 to 0.3.4.
- Add a changelog entry for 0.3.4, including the `pkg_resources` deprecation fix from f0d50b3.
- Fix Read the Docs builds broken by the `nbconvert` 7 upgrade (#9):
  - Replace `m2r2` with `myst-parser` in the Sphinx docs toolchain.
  - Install the package during RTD builds so autodoc can import `reprexpy`.
  - Fix Sphinx toctree/include warnings that fail under `-W`.
- Add a `Docs` CI job that mirrors the RTD build on every PR.
- Update `make docs` to run the same strict local docs build.
