### PR TITLE
Release 0.3.4 to PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.4
+## 0.3.4 (2026-06-09)
 
 - Replaced deprecated `pkg_resources` usage in session information reporting.
 - Updated supporting documentation and dependency metadata for the current release.


### PR DESCRIPTION
## Summary
- Publish the final `0.3.4` release to PyPI.
- The accidental `0.3.4.dev1` upload came from the `codex/0.3.4-dev1` test branch; `master` already has the correct `0.3.4` version in `setup.py` and `docs/source/conf.py`.
- Add a release date to the 0.3.4 changelog entry.

## Test plan
- [x] `pytest` passes locally (14 tests)
- [ ] Merge PR
- [ ] Build and upload `0.3.4` to PyPI
- [ ] Verify `pip install reprexpy==0.3.4` works


Made with [Cursor](https://cursor.com)